### PR TITLE
Change domain from int to bytes8

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,21 +48,22 @@ function g1() {
 
 /**
  * @param {bytes32} messageHash
- * @param {int} domain
+ * @param {bytes8} domain
  * @returns {mcl.G2} g2
  */
 function hashToG2 (messageHash, domain) {
   assert.equal(messageHash.length, 32, 'messageHash must be 32 bytes long')
+  assert.equal(domain.length, 8, 'domain must be 8 bytes long')
 	const xReal = keccak256(Buffer.concat([
     messageHash,
-    Buffer.alloc(1, domain),
+    domain,
     Buffer.from([1]),
   ]))
   const xRealFp = new mcl.Fp()
   xRealFp.setLittleEndian(xReal)
 	const xImag = keccak256(Buffer.concat([
     messageHash,
-    Buffer.alloc(1, domain),
+    domain,
     Buffer.from([2]),
   ]))
   const xImagFp = new mcl.Fp()
@@ -101,7 +102,7 @@ function aggregateSignatures(signatures) {
  * @param {bytes48} pubkey
  * @param {bytes32} messageHash
  * @param {bytes96} signature
- * @param {int} domain
+ * @param {bytes8} domain
  * @returns {boolean}
  */
 function verify (pubkey, messageHash, signature, domain) {
@@ -114,7 +115,7 @@ function verify (pubkey, messageHash, signature, domain) {
  * @param {Array<bytes48>} pubkeys
  * @param {Array<bytes32>} messageHashes
  * @param {bytes96} signature
- * @param {int} domain
+ * @param {bytes8} domain
  * @returns {boolean}
  */
 function verifyMultiple (pubkeys, messageHashes, signature, domain) {
@@ -137,7 +138,7 @@ function verifyMultiple (pubkeys, messageHashes, signature, domain) {
  * Utility function used to hash messageHash and domain to G2 and do a pairing with pubkey
  * @param {mcl.G1} pubkey
  * @param {bytes32} messageHash
- * @param {int} domain
+ * @param {bytes8} domain
  * @returns {mcl.GT}
  */
 function toG2AndPairing (pubkey, messageHash, domain) {

--- a/test/bls_test.js
+++ b/test/bls_test.js
@@ -15,7 +15,7 @@ describe("bls", () => {
 	})
 
 	it("should hash message to G2", () => {
-		const domain = 0
+		const domain = Buffer.alloc(8)
 		const message = keccak256(Buffer.from('6d657373616765', 'hex'))
 		assert(bls.hashToG2(message, domain))
 	})
@@ -68,15 +68,15 @@ describe("bls", () => {
     assert(s.getStr(16) === secret)
 
     const msg = keccak256(Buffer.from("6d657373616765", 'hex'))
-    const domain = 0
-	  const sig = bls.sign(Buffer.from(s.serialize()), msg, 0)
+    const domain = Buffer.alloc(8)
+	  const sig = bls.sign(Buffer.from(s.serialize()), msg, domain)
 		assert(sig.length === 96)
 	})
 
 	it("should verify a signature", () => {
     const s = bls.genSecret()
     const P = bls.genPublic(s)
-		const domain = 0
+		const domain = Buffer.alloc(8)
 		const msg = keccak256(Buffer.from("hello", "hex"))
 		const sig = bls.sign(s, msg, domain)
 		assert(bls.verify(P, msg, sig, domain), "did not verify aggregated signature")
@@ -103,7 +103,7 @@ describe("bls", () => {
 	it("should verify an aggregated signature of 1", () => {
     const s = bls.genSecret()
     const P = bls.genPublic(s)
-		const domain = 0
+		const domain = Buffer.alloc(8)
 		const msg = keccak256(Buffer.from("hello", "hex"))
 		const sig = bls.sign(s, msg, domain)
 		assert(bls.verifyMultiple([P], [msg], sig, domain), "did not verify aggregated signature")
@@ -114,7 +114,7 @@ describe("bls", () => {
     const P1 = bls.genPublic(s1)
     const s2 = bls.genSecret()
     const P2 = bls.genPublic(s2)
-		const domain = 0
+		const domain = Buffer.alloc(8)
 		const msg = keccak256(Buffer.from("hello", "hex"))
 		const sig1 = bls.sign(s1, msg, domain)
 		const sig2 = bls.sign(s2, msg, domain)


### PR DESCRIPTION
Previous implementation is incorrect (domain serialized to a single byte)

I think passing in a bytes8 is preferable, providing more uniformity in the function interface (only dealing with byte arrays now), and we won't have to deal with int/bigint serialization choices here.